### PR TITLE
fix stat number json crash

### DIFF
--- a/vimeo_dl/extractor.py
+++ b/vimeo_dl/extractor.py
@@ -39,14 +39,14 @@ def _extract_json(url):
             "height"        : json[0]['height'],
             "width"         : json[0]['width'],
             "upload_date"   : json[0]['upload_date'],
-            "likes"         : json[0]['stats_number_of_likes'],
-            "comments"      : json[0]['stats_number_of_comments'],
+            "likes"         : json[0].get('stats_number_of_likes', None),
+            "comments"      : json[0].get('stats_number_of_comments', None),
             "user_url"      : json[0]['user_url'],
             "video_id"      : json[0]['id'],
             "duration"      : json[0]['duration'],
             "user_id"       : json[0]['user_id'],
             "url"           : json[0]['url'],
-            "viewed"        : json[0]['stats_number_of_plays'],
+            "viewed"        : json[0].get('stats_number_of_plays', None),
             }
         return json_info
 


### PR DESCRIPTION
in extractor.py, some video json does not have stats_number_of_*. so use dict.get() and set None if there is no stats.